### PR TITLE
fix: enable multithreading for cc_binary 

### DIFF
--- a/patches/add_build_file.patch
+++ b/patches/add_build_file.patch
@@ -65,7 +65,7 @@ index 00000000..f8b9c939
 +        "//conditions:default": ["-pthread"],
 +    }),
 +    linkstatic = True,
-+    local_defines = [
++    defines = [
 +        "XXH_NAMESPACE=ZSTD_",
 +        "ZSTD_MULTITHREAD",
 +        "ZSTD_BUILD_SHARED=OFF",


### PR DESCRIPTION
Enable multithreading for the binary

use defines instead of local_defines to make sure that the required options are passed to targets depending on cc_library:zstd

---

### Changes are visible to end-users: yes

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

Release note: fix multithreading for the binary

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
- Manual testing; please provide instructions so we can reproduce:
Invoking binary with multiple threads should not generate this warning anymore: 
<img width="792" height="37" alt="image" src="https://github.com/user-attachments/assets/647b0509-8499-43ca-92ae-9c268f814f27" />
